### PR TITLE
add unit for distance "m"

### DIFF
--- a/custom_components/xiaomi_gateway3/sensor.py
+++ b/custom_components/xiaomi_gateway3/sensor.py
@@ -38,18 +38,18 @@ UNITS = {
     "humidity": PERCENTAGE,
     # zb light and motion and ble flower - lux
     "illuminance": LIGHT_LUX,
-    "power": POWER_WATT,
-    "voltage": ELECTRIC_POTENTIAL_VOLT,
-    "current": ELECTRIC_CURRENT_AMPERE,
-    "pressure": PRESSURE_HPA,
-    "temperature": TEMP_CELSIUS,
-    "energy": ENERGY_KILO_WATT_HOUR,
-    "chip_temperature": TEMP_CELSIUS,
+    "power": POWER_WATT, # Deprecated: please use UnitOfPower.WATT.
+    "voltage": ELECTRIC_POTENTIAL_VOLT, # Deprecated: please use UnitOfElectricPotential.VOLT.
+    "current": ELECTRIC_CURRENT_AMPERE, # Deprecated: please use UnitOfElectricCurrent.AMPERE.
+    "pressure": PRESSURE_HPA,  # Deprecated: please use UnitOfPressure.HPA
+    "temperature": TEMP_CELSIUS, # Deprecated: please use UnitOfTemperature.CELSIUS
+    "energy": ENERGY_KILO_WATT_HOUR, # Deprecated: please use UnitOfEnergy.KILO_WATT_HOUR.
+    "chip_temperature": TEMP_CELSIUS, # Deprecated: please use UnitOfTemperature.CELSIUS
     "conductivity": CONDUCTIVITY,
     "gas_density": "% LEL",
-    "idle_time": TIME_SECONDS,
+    "idle_time": TIME_SECONDS, # Deprecated: please use UnitOfTime.SECONDS.
     "linkquality": "lqi",
-    "max_power": POWER_WATT,
+    "max_power": POWER_WATT, # Deprecated: please use UnitOfPower.WATT.
     "moisture": PERCENTAGE,
     "msg_received": "msg",
     "msg_missed": "msg",
@@ -58,7 +58,8 @@ UNITS = {
     "rssi": SIGNAL_STRENGTH_DECIBELS_MILLIWATT,
     "smoke_density": "% obs/ft",
     "supply": PERCENTAGE,
-    "tvoc": CONCENTRATION_PARTS_PER_BILLION,
+    "tvoc": CONCENTRATION_PARTS_PER_BILLION, 
+    "distance": LENGTH_METERS, # Deprecated: please use UnitOfLength.METERS.
     # "link_quality": "lqi",
     # "rssi": "dBm",
     # "msg_received": "msg",


### PR DESCRIPTION
Logger: homeassistant.components.sensor
Source: components/sensor/__init__.py:674
Integration: 传感器 ([documentation](https://www.home-assistant.io/integrations/sensor), [issues](https://github.com/home-assistant/home-assistant/issues?q=is%3Aissue+is%3Aopen+label%3A%22integration%3A+sensor%22))
First occurred: 20:37:46 (1 occurrences)
Last logged: 20:37:46

Entity sensor.ccb5d1d4a593_distance (<class 'custom_components.xiaomi_gateway3.sensor.XiaomiSensor'>) is using native unit of measurement 'None' which is not a valid unit for the device class ('distance') it is using; expected one of ['ft', 'm', 'km', 'mm', 'in', 'mi', 'yd', 'cm']; Please update your configuration if your entity is manually configured, otherwise report it to the custom integration author.